### PR TITLE
cannot cast TextView to Parcelable

### DIFF
--- a/markdown/src/main/java/com/zzhoujay/markdown/style/MarkDownBulletSpan.java
+++ b/markdown/src/main/java/com/zzhoujay/markdown/style/MarkDownBulletSpan.java
@@ -153,7 +153,6 @@ public class MarkDownBulletSpan extends BulletSpan {
         dest.writeString(this.index);
         dest.writeInt(this.level);
         dest.writeInt(this.margin);
-        dest.writeParcelable((Parcelable) this.textViewWeakReference.get(), flags);
     }
 
     protected MarkDownBulletSpan(Parcel in) {


### PR DESCRIPTION
This will cause an exception when using RichText. When clicking a link
in a bullet to start a new activity, the system (Android 5.0) will call
writeToParcel method and then report an exception because casting TextView
to Parcelable, but it is not a parcelable object.